### PR TITLE
Fix JSZip loading order

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,8 +79,8 @@
       </div>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.44.0/min/vs/loader.min.js"></script>
     <script src="lib/jszip.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.44.0/min/vs/loader.min.js"></script>
     <script src="js/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load `jszip.min.js` before the AMD loader for Monaco

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a261b27b0832ebea661a32b2360b1