### PR TITLE
Add decoded resource download and read-only editor

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -65,6 +65,22 @@ input[type="file"] {
   box-shadow: 0 5px 15px rgba(0, 102, 204, 0.3);
 }
 
+.download-btn {
+  background: linear-gradient(135deg, #28a745 0%, #218838 100%);
+  color: white;
+  border: none;
+  padding: 12px 30px;
+  border-radius: 25px;
+  cursor: pointer;
+  font-size: 16px;
+  transition: all 0.3s ease;
+}
+
+.download-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 5px 15px rgba(40, 167, 69, 0.3);
+}
+
 .results {
   margin-top: 20px;
 }

--- a/index.html
+++ b/index.html
@@ -51,6 +51,9 @@
         </div>
 
         <div id="results" class="results"></div>
+        <div id="downloadSection" class="result-section" style="display: none; text-align: center;">
+          <button id="downloadBtn" class="download-btn">⬇️ Baixar Recursos Decodificados</button>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add a download button inside the result section for getting a zip of decoded resources
- style the new download button
- make the Monaco editor read‑only
- implement JS logic to build the download zip

## Testing
- `npx eslint js/main.js` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_688a56a467c8832e92d8d7f18f89f5dd