### PR TITLE
Fix format button to pretty-print XML

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -116,11 +116,35 @@ copyBtn.addEventListener("click", () => {
 });
 
 // Format/Pretty Print button
+function prettyPrintXML(xml) {
+  const PADDING = "  ";
+  xml = xml.replace(/(>)(<)(\/?)/g, "$1\n$2$3");
+  let formatted = "";
+  let pad = 0;
+  xml.split(/\n/).forEach((node) => {
+    if (node.match(/^<\/.+/)) {
+      pad -= 1;
+    }
+    formatted += PADDING.repeat(pad) + node + "\n";
+    if (node.match(/^<[^!?]+[^\/]>/) && !node.match(/<\/.+>/)) {
+      pad += 1;
+    }
+  });
+  return formatted.trim();
+}
+
 formatBtn.addEventListener("click", () => {
   if (monacoEditor) {
-    const action = monacoEditor.getAction("editor.action.formatDocument");
-    if (action) {
-      action.run();
+    const model = monacoEditor.getModel();
+    const language = model ? model.getLanguageId() : "";
+    if (language === "xml") {
+      const formatted = prettyPrintXML(monacoEditor.getValue());
+      monacoEditor.setValue(formatted);
+    } else {
+      const action = monacoEditor.getAction("editor.action.formatDocument");
+      if (action) {
+        action.run();
+      }
     }
   }
 });


### PR DESCRIPTION
## Summary
- add `prettyPrintXML` helper to format linearized XML
- conditionally use custom XML formatter when clicking Format button

## Testing
- `node <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_688a67bc89ac832e8c25aa73e563f1d5