### PR TITLE
Add BPMN view button for IFLW

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ O SAP CPI Package Decoder é uma aplicação web client-side que permite aos des
 - **Visualização de metadados**: Exibe informações detalhadas do pacote (`contentmetadata.md`)
 - **Exploração de recursos**: Lista e permite visualizar todos os recursos do pacote (`resources.cnt`)
 - **Visualização de scripts**: Suporte para ScriptCollections e scripts individuais (Groovy, JavaScript, etc.)
+- **Visualização de BPMN**: Botão para exibir arquivos `.iflw` como diagramas BPMN
 - **Interface intuitiva**: Drag & drop ou seleção de arquivos
 - **Processamento local**: Toda a decodificação acontece no navegador (sem upload para servidores)
 

--- a/bpmn_viewer.html
+++ b/bpmn_viewer.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>BPMN Viewer</title>
+<link rel="stylesheet" href="https://unpkg.com/bpmn-js@10.1.0/dist/assets/bpmn-js.css">
+<style>
+  html, body { height: 100%; margin: 0; }
+  #canvas { width: 100%; height: 100%; }
+</style>
+</head>
+<body>
+<div id="canvas"></div>
+<script src="https://unpkg.com/bpmn-js@10.1.0/dist/bpmn-viewer.development.js"></script>
+<script>
+(function(){
+  const params = new URLSearchParams(window.location.search);
+  const data = params.get('data');
+  if (!data) {
+    document.body.innerHTML = '<p>No BPMN data provided.</p>';
+    return;
+  }
+  const xml = atob(data);
+  const viewer = new BpmnJS({ container: '#canvas' });
+  viewer.importXML(xml).then(function(){
+    viewer.get('canvas').zoom('fit-viewport');
+  }).catch(function(err){
+    document.body.innerHTML = '<pre>Erro ao carregar diagrama: ' + err + '</pre>';
+  });
+})();
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
             <select id="fileSelect" class="file-select"></select>
             <button id="formatBtn" class="control-btn" title="Formatar código">✨</button>
             <button id="copyBtn" class="control-btn" title="Copiar conteúdo">📋</button>
+            <button id="bpmnBtn" class="control-btn" title="Visualizar BPMN" style="display:none;">🗺️</button>
             <button id="fullscreenBtn" class="control-btn" title="Tela cheia">⛶</button>
             <button id="closeModal" class="close-btn">&times;</button>
           </div>

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,7 @@ const languageSelect = document.getElementById("languageSelect");
 const fileSelect = document.getElementById("fileSelect");
 const formatBtn = document.getElementById("formatBtn");
 const copyBtn = document.getElementById("copyBtn");
+const bpmnBtn = document.getElementById("bpmnBtn");
 const fullscreenBtn = document.getElementById("fullscreenBtn");
 const downloadBtn = document.getElementById("downloadBtn");
 
@@ -17,6 +18,7 @@ let monacoEditor = null;
 let isFullscreen = false;
 let currentFiles = {};
 let originalZipName = "";
+let currentFileName = "";
 
 function getFileContent(fileName) {
   if (fileContents[fileName]) {
@@ -113,6 +115,19 @@ copyBtn.addEventListener("click", () => {
         }, 2000);
       });
   }
+});
+
+// Visualizar BPMN
+bpmnBtn.addEventListener("click", () => {
+  if (!monacoEditor) return;
+  const ext = currentFileName.split('.').pop().toLowerCase();
+  if (ext !== 'iflw' && ext !== 'bpmn' && ext !== 'xml') {
+    alert('Arquivo atual não é um IFLW/BPMN.');
+    return;
+  }
+  const xml = monacoEditor.getValue();
+  const encoded = btoa(unescape(encodeURIComponent(xml)));
+  window.open(`bpmn_viewer.html?data=${encoded}`, '_blank');
 });
 
 // Format/Pretty Print button
@@ -384,6 +399,12 @@ function setEditorContent(content, fileName) {
   languageSelect.value = language;
   monaco.editor.setModelLanguage(monacoEditor.getModel(), language);
   monacoEditor.setValue(content);
+  currentFileName = fileName;
+  if (fileName.toLowerCase().endsWith('.iflw') || fileName.toLowerCase().endsWith('.bpmn')) {
+    bpmnBtn.style.display = 'inline-block';
+  } else {
+    bpmnBtn.style.display = 'none';
+  }
 }
 
 /**
@@ -397,6 +418,7 @@ function closeEditorModal() {
   fileSelect.style.display = "none";
   fileSelect.innerHTML = "";
   currentFiles = {};
+  bpmnBtn.style.display = "none";
 
   if (isFullscreen) {
     exitFullscreen();


### PR DESCRIPTION
## Summary
- allow viewing `*.iflw` files as BPMN diagrams
- add dedicated BPMN viewer page
- expose BPMN view button in modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a77fde568832eb7de38246ae05af3