### PR TITLE
Fix BPMN viewer modal handling

### DIFF
--- a/bpmn_viewer.html
+++ b/bpmn_viewer.html
@@ -15,12 +15,12 @@
 <script>
 (function(){
   const params = new URLSearchParams(window.location.search);
-  const data = params.get('data');
-  if (!data) {
-    document.body.innerHTML = '<p>No BPMN data provided.</p>';
-    return;
-  }
-  const xml = atob(data);
+  const dataParam = params.get('data');
+  if (!dataParam) {
+      document.body.innerHTML = '<p>No BPMN data provided.</p>';
+      return;
+    }
+    const xml = atob(decodeURIComponent(dataParam));
   const viewer = new BpmnJS({ container: '#canvas' });
   viewer.importXML(xml).then(function(){
     viewer.get('canvas').zoom('fit-viewport');

--- a/css/style.css
+++ b/css/style.css
@@ -338,3 +338,10 @@ input[type="file"] {
     opacity: 1;
   }
 }
+
+/* BPMN Viewer frame */
+#bpmnFrame {
+  flex: 1;
+  width: 100%;
+  border: none;
+}

--- a/index.html
+++ b/index.html
@@ -86,6 +86,17 @@
       </div>
     </div>
 
+    <!-- Modal for BPMN Viewer -->
+    <div id="bpmnModal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>BPMN Viewer</h3>
+          <button id="closeBpmnModal" class="close-btn">&times;</button>
+        </div>
+        <iframe id="bpmnFrame" style="flex:1;width:100%;border:none;"></iframe>
+      </div>
+    </div>
+
     <script src="lib/jszip.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.44.0/min/vs/loader.min.js"></script>
     <script src="js/main.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -11,6 +11,9 @@ const copyBtn = document.getElementById("copyBtn");
 const bpmnBtn = document.getElementById("bpmnBtn");
 const fullscreenBtn = document.getElementById("fullscreenBtn");
 const downloadBtn = document.getElementById("downloadBtn");
+const bpmnModal = document.getElementById("bpmnModal");
+const bpmnFrame = document.getElementById("bpmnFrame");
+const closeBpmnModal = document.getElementById("closeBpmnModal");
 
 let fileContents = {}; // Armazena o conteúdo dos arquivos do ZIP principal
 let resourcesCntDecoded = "";
@@ -67,6 +70,14 @@ fileInput.addEventListener("change", (e) => {
 
 // --- Modal Event Listeners ---
 closeModal.addEventListener("click", closeEditorModal);
+closeBpmnModal.addEventListener("click", closeBpmnViewer);
+
+// Close BPMN modal when clicking outside
+bpmnModal.addEventListener("click", (e) => {
+  if (e.target === bpmnModal) {
+    closeBpmnViewer();
+  }
+});
 
 // Close modal when clicking outside
 modal.addEventListener("click", (e) => {
@@ -120,14 +131,18 @@ copyBtn.addEventListener("click", () => {
 // Visualizar BPMN
 bpmnBtn.addEventListener("click", () => {
   if (!monacoEditor) return;
-  const ext = currentFileName.split('.').pop().toLowerCase();
-  if (ext !== 'iflw' && ext !== 'bpmn' && ext !== 'xml') {
-    alert('Arquivo atual não é um IFLW/BPMN.');
+  const ext = currentFileName.split(".").pop().toLowerCase();
+  if (ext !== "iflw" && ext !== "bpmn" && ext !== "xml") {
+    alert("Arquivo atual não é um IFLW/BPMN.");
     return;
   }
   const xml = monacoEditor.getValue();
-  const encoded = btoa(unescape(encodeURIComponent(xml)));
-  window.open(`bpmn_viewer.html?data=${encoded}`, '_blank');
+  const base64 = btoa(unescape(encodeURIComponent(xml)));
+  const encoded = encodeURIComponent(base64);
+  bpmnFrame.src = `bpmn_viewer.html?data=${encoded}`;
+  bpmnModal.style.display = "block";
+  bpmnModal.classList.add("show");
+  bpmnModal.querySelector(".modal-content").classList.add("show");
 });
 
 // Format/Pretty Print button
@@ -423,6 +438,13 @@ function closeEditorModal() {
   if (isFullscreen) {
     exitFullscreen();
   }
+}
+
+function closeBpmnViewer() {
+  bpmnModal.style.display = "none";
+  bpmnModal.classList.remove("show");
+  bpmnModal.querySelector(".modal-content").classList.remove("show");
+  bpmnFrame.src = "";
 }
 
 /**


### PR DESCRIPTION
## Summary
- encode data parameter for BPMN viewer
- add BPMN viewer modal to index
- style BPMN viewer iframe
- open BPMN viewer inside modal instead of new tab

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a9ce83744832eab406c646852b5f6