### PR TITLE
Add iFlow ZIP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ O SAP CPI Package Decoder é uma aplicação web client-side que permite aos des
 - **Exploração de recursos**: Lista e permite visualizar todos os recursos do pacote (`resources.cnt`)
 - **Visualização de scripts**: Suporte para ScriptCollections e scripts individuais (Groovy, JavaScript, etc.)
 - **Visualização de BPMN**: Botão para exibir arquivos `.iflw` como diagramas BPMN
+- **Suporte a artefatos de iFlow**: Permite carregar arquivos ZIP exportados diretamente de um iFlow
 - **Interface intuitiva**: Drag & drop ou seleção de arquivos
 - **Processamento local**: Toda a decodificação acontece no navegador (sem upload para servidores)
 
@@ -22,6 +23,7 @@ O SAP CPI Package Decoder é uma aplicação web client-side que permite aos des
    - No SAP CPI Web UI, vá para o seu pacote de integração
    - Clique em "Actions" → "Export"
    - Baixe o arquivo `.zip` resultante
+   - Também é possível exportar individualmente um iFlow (ZIP) e carregá-lo
 
 2. **Carregue o arquivo na ferramenta**:
    - Abra o `index.html` no seu navegador
@@ -89,6 +91,7 @@ A ferramenta processa os seguintes arquivos do pacote SAP CPI:
 | `contentmetadata.md` | Metadados do pacote | Base64 → Text |
 | `resources.cnt` | Lista de recursos | Base64 → JSON |
 | `{resourceId}_content` | Conteúdo dos recursos | Binary/ZIP → Text/Scripts |
+| `IFlow.zip` | Artefato iFlow exportado | ZIP → Text/BPMN |
 
 ## 🔍 Tipos de Recursos Suportados
 

--- a/js/main.js
+++ b/js/main.js
@@ -194,7 +194,9 @@ document.addEventListener("keydown", (e) => {
 // --- Listener de Eventos Generalizado ---
 results.addEventListener("click", function (e) {
   const scriptItem = e.target.closest(".script-item");
-  if (scriptItem && scriptItem.dataset.resourceId) {
+  if (!scriptItem) return;
+
+  if (scriptItem.dataset.resourceId) {
     const resourceId = scriptItem.dataset.resourceId;
     const resourceName = scriptItem.querySelector(".script-name").textContent;
     const resourceType = scriptItem.dataset.resourceType;
@@ -211,6 +213,9 @@ results.addEventListener("click", function (e) {
     }
 
     openResourceInMonaco(resourceId, resourceName, resourceType);
+  } else if (scriptItem.dataset.filePath) {
+    const filePath = scriptItem.dataset.filePath;
+    openIflowFile(filePath);
   }
 });
 
@@ -232,9 +237,10 @@ function handleZipFile(file) {
     const promises = [];
     zip.forEach((relativePath, zipEntry) => {
       // Diferencia o conteúdo binário (_content) do conteúdo de texto
-      const fileType = zipEntry.name.endsWith("_content")
-        ? "arraybuffer"
-        : "string";
+      let fileType = "string";
+      if (zipEntry.name.endsWith("_content") || /\.(zip|jar)$/i.test(zipEntry.name)) {
+        fileType = "arraybuffer";
+      }
       const promise = zipEntry.async(fileType).then((content) => {
         fileContents[zipEntry.name] = content;
       });
@@ -244,16 +250,24 @@ function handleZipFile(file) {
     // Após carregar todos os arquivos, processa os principais
     Promise.all(promises).then(() => {
       const resourcesCnt = getFileContent("resources.cnt");
+      const contentMetadata = getFileContent("contentmetadata.md");
+
       if (resourcesCnt) {
         processFile("resources.cnt", resourcesCnt);
       }
-      const contentMetadata = getFileContent("contentmetadata.md");
       if (contentMetadata) {
         processFile("contentmetadata.md", contentMetadata);
       }
 
-      if (downloadSection) {
-        downloadSection.style.display = "block";
+      if (!resourcesCnt && !contentMetadata) {
+        displayIflowFileList();
+        if (downloadSection) {
+          downloadSection.style.display = "none";
+        }
+      } else {
+        if (downloadSection) {
+          downloadSection.style.display = "block";
+        }
       }
     });
   });
@@ -295,6 +309,30 @@ function openResourceInMonaco(resourceId, resourceName, resourceType) {
     });
   } else {
     loadContentIntoMonaco(content, fileName);
+  }
+}
+
+/**
+ * Abre um arquivo individual de um iFlow ZIP
+ */
+function openIflowFile(filePath) {
+  const content = getFileContent(filePath);
+  if (!content) {
+    alert("Arquivo não encontrado: " + filePath);
+    return;
+  }
+
+  modalTitle.textContent = `📄 ${filePath}`;
+  modal.style.display = "block";
+  modal.classList.add("show");
+  modal.querySelector(".modal-content").classList.add("show");
+
+  if (!monacoEditor) {
+    require(["vs/editor/editor.main"], function () {
+      initializeMonacoEditor(content, filePath);
+    });
+  } else {
+    loadContentIntoMonaco(content, filePath);
   }
 }
 
@@ -564,6 +602,27 @@ function processFile(fileName, content) {
   }
 }
 
+function displayIflowFileList() {
+  const files = Object.keys(fileContents).filter((name) => !name.endsWith("/"));
+  if (files.length === 0) return;
+
+  const resultDiv = document.createElement("div");
+  resultDiv.className = "result-section";
+  let html = '<div class="result-title">📂 Arquivos do IFlow</div>';
+  html += '<ul class="script-list">';
+  files.forEach((fn) => {
+    const displayName = fn.split("/").pop();
+    html += `<li class="script-item" data-file-path="${fn}">
+                <div class="script-name">${displayName}</div>
+                <div class="script-type">${fn}</div>
+             </li>`;
+  });
+  html += '</ul>';
+  html += '<p style="margin-top: 15px; color: #666; font-style: italic;">💡 Clique em qualquer arquivo para visualizar seu conteúdo.</p>';
+  resultDiv.innerHTML = html;
+  results.appendChild(resultDiv);
+}
+
 /**
  * Formata as informações dos recursos para exibição em uma lista.
  */
@@ -711,3 +770,4 @@ function downloadResources() {
     });
   });
 }
+


### PR DESCRIPTION
## Summary
- add support for uploading exported iFlow ZIPs
- show iFlow files when no `resources.cnt` is present
- hide download button for standalone iFlow zips
- document iFlow ZIP support

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688ab6f29a0c832e977105d41c4f5144