### PR TITLE
Hide download button for iFlow ZIP

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -264,7 +264,11 @@ function handleZipFile(file) {
       }
 
       if (downloadSection) {
-        downloadSection.style.display = "block";
+        if (resourcesCnt || contentMetadata) {
+          downloadSection.style.display = "block";
+        } else {
+          downloadSection.style.display = "none";
+        }
       }
     });
   });


### PR DESCRIPTION
## Summary
- adjust logic to only show download button when processing a package

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688abe3a9a80832e8b437e2e32e2e9c2