### PR TITLE
Add multilingual support

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -1,0 +1,165 @@
+# SAP CPI Package Decoder 🔓
+
+A web tool to decode and visualize the contents of packages exported from SAP Cloud Platform Integration (CPI).
+
+## 📋 Overview
+
+SAP CPI Package Decoder is a client-side web application that allows SAP CPI developers and administrators to inspect exported integration packages, including scripts, metadata and resources, without the need for external tools.
+
+## ✨ Features
+- **Automatic decoding**: Processes `.zip` files exported from SAP CPI
+- **Metadata view**: Shows detailed package information (`contentmetadata.md`)
+- **Resource exploration**: Lists and displays all package resources (`resources.cnt`)
+- **Script visualization**: Supports ScriptCollections and individual scripts (Groovy, JavaScript, etc.)
+- **BPMN visualization**: Button to show `.iflw` files as BPMN diagrams
+- **iFlow artifact support**: Load ZIPs exported directly from an iFlow
+- **Intuitive interface**: Drag & drop or file selection
+- **Local processing**: Everything runs in the browser (no uploads)
+
+## 🚀 How to Use
+
+1. **Export your SAP CPI package**
+   - In the SAP CPI Web UI, open your integration package
+   - Click "Actions" → "Export"
+   - Download the resulting `.zip` file
+   - You can also export an individual iFlow (ZIP) and load it
+
+2. **Load the file in the tool**
+   - Open `index.html` in your browser
+   - Drag the `.zip` file to the upload area OR
+   - Click "Select ZIP File" and choose the file
+
+3. **Explore the content**
+   - See the package metadata
+   - Click any resource in the list to view its contents
+   - Scripts and ScriptCollections are decoded automatically
+
+## 📁 Project Structure
+```
+sap-cpi-decoder/
+├── index.html              # Main page
+├── css/
+│   └── style.css           # Interface styles
+├── js/
+│   ├── globals.js         # Globals and configuration
+│   ├── editor.js          # Monaco Editor functions
+│   ├── fileLoader.js      # ZIP and resource processing
+│   └── uiHandlers.js      # UI events
+├── lib/
+│   └── jszip.min.js        # ZIP processing library
+├── .vscode/
+│   └── launch.json         # VS Code debug config
+├── .gitattributes          # Git settings
+└── README.md               # This documentation
+```
+
+## 🛠️ Technologies Used
+- **HTML5**: Application structure
+- **CSS3**: Modern interface with gradients and animations
+- **JavaScript (ES6+)**: Processing logic
+- **JSZip**: Library for ZIP files
+- **FileReader API**: Local file reading
+- **Base64 Decoding**: Decode encoded content
+
+## 🔧 Development Setup
+
+### Prerequisites
+- Modern web browser (Chrome, Firefox, Safari, Edge)
+- Code editor (recommended: VS Code)
+
+### Running Locally
+
+1. **Clone or download the project**
+2. **Open in VS Code** (optional)
+3. **Use one of the methods**:
+   - **Method 1**: Open `index.html` directly in the browser
+   - **Method 2**: Use VS Code's Live Server extension
+   - **Method 3**: Use the provided debug config (F5 in VS Code)
+
+### VS Code Debug
+
+The project includes a debug configuration (`.vscode/launch.json`):
+- Press `F5` to start debugging
+- Or go to "Run and Debug" → "Launch in Browser"
+
+## 📦 Processed Files
+
+The tool handles the following files from a SAP CPI package:
+
+| File | Description | Format |
+|------|-------------|-------|
+| `contentmetadata.md` | Package metadata | Base64 → Text |
+| `resources.cnt` | Resource list | Base64 → JSON |
+| `{resourceId}_content` | Resource contents | Binary/ZIP → Text/Scripts |
+| `IFlow.zip` | Exported iFlow artifact | ZIP → Text/BPMN |
+
+## 🔍 Supported Resource Types
+- **ScriptCollection**: Script collections (internal ZIP)
+- **Groovy Scripts**: Individual Groovy scripts
+- **JavaScript**: JavaScript scripts
+- **XML**: Configurations and mappings
+- **Properties**: Properties files
+- **Others**: General text files
+
+## 🎨 Interface
+
+The application provides a modern responsive interface with:
+- **Gradients**: Eye-catching design
+- **Drag & Drop**: Interactive upload area
+- **Animations**: Smooth visual feedback
+- **Responsive**: Works on various screen sizes
+- **Code highlighting**: Better readability
+
+## 🔒 Security & Privacy
+- **Local processing**: No files are sent to servers
+- **Client-side only**: All decoding happens in the browser
+- **No external dependencies**: Only local libraries
+- **Open source**: Fully auditable
+
+## 🐛 Troubleshooting
+
+### File doesn't load
+- Ensure it is a valid SAP CPI `.zip` file
+- Make sure the file is not corrupted
+
+### Decoding error
+- Some resources may not be supported
+- Check the browser console for details
+
+### Interface doesn't load
+- Check if all files are in the correct place
+- Make sure JavaScript is enabled
+
+## 🤝 Contributions
+
+Contributions are welcome! To contribute:
+
+1. Fork the project
+2. Create a branch for your feature (`git checkout -b feature/AmazingFeature`)
+3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
+4. Push to the branch (`git push origin feature/AmazingFeature`)
+5. Open a Pull Request
+
+## 📝 Changelog
+
+### v1.0.0
+- Initial decoding functionality
+- Support for metadata and resources
+- Drag & drop interface
+- ScriptCollections view
+
+## 📄 License
+
+This project is open source. See the LICENSE file for details.
+
+## 🆘 Support
+
+For issues or questions:
+- Open an issue in the repository
+- Check the SAP CPI documentation
+- See the troubleshooting section above
+
+## 🙏 Acknowledgments
+
+- Open source community for the JSZip library
+- Developers who provided feedback and improvements

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,0 +1,165 @@
+# SAP CPI Package Decoder 🔓
+
+Una herramienta web para decodificar y visualizar el contenido de paquetes exportados desde SAP Cloud Platform Integration (CPI).
+
+## 📋 Visión General
+
+SAP CPI Package Decoder es una aplicación web que funciona completamente del lado del cliente, permitiendo a desarrolladores y administradores de SAP CPI inspeccionar paquetes de integración exportados, incluidos scripts, metadatos y recursos sin necesidad de herramientas externas.
+
+## ✨ Funcionalidades
+- **Decodificación automática**: Procesa archivos `.zip` exportados de SAP CPI
+- **Visualización de metadatos**: Muestra información detallada del paquete (`contentmetadata.md`)
+- **Exploración de recursos**: Lista y permite ver todos los recursos del paquete (`resources.cnt`)
+- **Visualización de scripts**: Compatible con ScriptCollections y scripts individuales (Groovy, JavaScript, etc.)
+- **Visualización de BPMN**: Botón para mostrar archivos `.iflw` como diagramas BPMN
+- **Soporte para artefactos iFlow**: Permite cargar ZIPs exportados directamente de un iFlow
+- **Interfaz intuitiva**: Arrastrar y soltar o selección de archivos
+- **Procesamiento local**: Toda la decodificación ocurre en el navegador
+
+## 🚀 Cómo Usar
+
+1. **Exporta el paquete de SAP CPI**
+   - En la interfaz web de SAP CPI ve a tu paquete de integración
+   - Haz clic en "Actions" → "Export"
+   - Descarga el archivo `.zip` resultante
+   - También puedes exportar un iFlow individual (ZIP) y cargarlo
+
+2. **Carga el archivo en la herramienta**
+   - Abre `index.html` en tu navegador
+   - Arrastra el archivo `.zip` al área de carga O
+   - Haz clic en "Seleccionar Archivo ZIP" y elige el archivo
+
+3. **Explora el contenido**
+   - Visualiza los metadatos del paquete
+   - Haz clic en cualquier recurso de la lista para ver su contenido
+   - Los scripts y ScriptCollections se decodificarán automáticamente
+
+## 📁 Estructura del Proyecto
+```
+sap-cpi-decoder/
+├── index.html              # Página principal de la aplicación
+├── css/
+│   └── style.css           # Estilos de la interfaz
+├── js/
+│   ├── globals.js         # Variables y configuración general
+│   ├── editor.js          # Funciones del editor Monaco
+│   ├── fileLoader.js      # Procesamiento de ZIP y recursos
+│   └── uiHandlers.js      # Eventos de la interfaz
+├── lib/
+│   └── jszip.min.js        # Biblioteca para manejar ZIP
+├── .vscode/
+│   └── launch.json         # Configuración de depuración para VS Code
+├── .gitattributes          # Configuración de Git
+└── README.md               # Esta documentación
+```
+
+## 🛠️ Tecnologías Utilizadas
+- **HTML5**: Estructura de la aplicación
+- **CSS3**: Interfaz moderna con gradientes y animaciones
+- **JavaScript (ES6+)**: Lógica de procesamiento
+- **JSZip**: Biblioteca para archivos ZIP
+- **FileReader API**: Lectura de archivos locales
+- **Base64 Decoding**: Decodificación de contenido
+
+## 🔧 Configuración de Desarrollo
+
+### Requisitos Previos
+- Navegador web moderno (Chrome, Firefox, Safari, Edge)
+- Editor de código (recomendado: VS Code)
+
+### Ejecución Local
+
+1. **Clona o descarga el proyecto**
+2. **Ábrelo en VS Code** (opcional)
+3. **Ejecuta uno de los métodos**:
+   - **Método 1**: Abre `index.html` directamente en el navegador
+   - **Método 2**: Usa la extensión Live Server de VS Code
+   - **Método 3**: Usa la configuración de depuración (F5 en VS Code)
+
+### Depuración en VS Code
+
+El proyecto incluye configuración de depuración (`.vscode/launch.json`):
+- Presiona `F5` para iniciar la depuración
+- O ve a **Run and Debug** → **Depurar en el Navegador**
+
+## 📦 Archivos Procesados
+
+La herramienta maneja los siguientes archivos del paquete SAP CPI:
+
+| Archivo | Descripción | Formato |
+|---------|-------------|---------|
+| `contentmetadata.md` | Metadatos del paquete | Base64 → Text |
+| `resources.cnt` | Lista de recursos | Base64 → JSON |
+| `{resourceId}_content` | Contenido de los recursos | Binary/ZIP → Text/Scripts |
+| `IFlow.zip` | Artefacto iFlow exportado | ZIP → Text/BPMN |
+
+## 🔍 Tipos de Recursos Soportados
+- **ScriptCollection**: Colecciones de scripts (ZIP interno)
+- **Groovy Scripts**: Scripts Groovy individuales
+- **JavaScript**: Scripts de JavaScript
+- **XML**: Configuraciones y mapeos
+- **Properties**: Archivos de propiedades
+- **Otros**: Archivos de texto en general
+
+## 🎨 Interfaz
+
+La aplicación cuenta con una interfaz moderna y responsiva con:
+- **Gradientes**: Diseño atractivo
+- **Arrastrar y soltar**: Área de carga interactiva
+- **Animaciones**: Retroalimentación visual suave
+- **Responsiva**: Funciona en varios tamaños de pantalla
+- **Resaltado de código**: Mejor legibilidad
+
+## 🔒 Seguridad y Privacidad
+- **Procesamiento local**: Ningún archivo se envía a servidores externos
+- **Solo del lado del cliente**: Toda la decodificación ocurre en el navegador
+- **Sin dependencias externas**: Solo librerías locales
+- **Código abierto**: Totalmente auditable
+
+## 🐛 Solución de Problemas
+
+### El archivo no carga
+- Verifica que sea un archivo `.zip` válido de SAP CPI
+- Asegúrate de que el archivo no esté corrupto
+
+### Error de decodificación
+- Algunos recursos pueden no estar soportados
+- Consulta la consola del navegador para más detalles
+
+### La interfaz no carga
+- Verifica que todos los archivos estén en la ubicación correcta
+- Asegúrate de que JavaScript esté habilitado
+
+## 🤝 Contribuciones
+
+¡Las contribuciones son bienvenidas! Para contribuir:
+
+1. Haz un fork del proyecto
+2. Crea una rama para tu funcionalidad (`git checkout -b feature/AmazingFeature`)
+3. Haz commit de tus cambios (`git commit -m 'Add some AmazingFeature'`)
+4. Haz push de la rama (`git push origin feature/AmazingFeature`)
+5. Abre un Pull Request
+
+## 📝 Changelog
+
+### v1.0.0
+- Funcionalidad inicial de decodificación
+- Soporte para metadatos y recursos
+- Interfaz de arrastrar y soltar
+- Visualización de ScriptCollections
+
+## 📄 Licencia
+
+Este proyecto es de código abierto. Consulta el archivo LICENSE para más detalles.
+
+## 🆘 Soporte
+
+Para problemas o dudas:
+- Abre una issue en el repositorio
+- Consulta la documentación de SAP CPI
+- Revisa la sección de solución de problemas arriba
+
+## 🙏 Agradecimientos
+
+- Comunidad open source por la biblioteca JSZip
+- Desarrolladores que contribuyeron con comentarios y mejoras

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Uma ferramenta web para decodificar e visualizar o conteúdo de pacotes exportados do SAP Cloud Platform Integration (CPI).
 
+Disponível também em [English](README.en-US.md) e [Español](README.es-ES.md).
+
 ## 📋 Visão Geral
 
 O SAP CPI Package Decoder é uma aplicação web client-side que permite aos desenvolvedores e administradores SAP CPI visualizar e examinar o conteúdo de pacotes de integração exportados, incluindo scripts, metadados e recursos sem a necessidade de ferramentas externas.

--- a/bpmn_viewer.html
+++ b/bpmn_viewer.html
@@ -16,8 +16,24 @@
 (function(){
   const params = new URLSearchParams(window.location.search);
   const dataParam = params.get('data');
+  const lang = params.get('lang') || 'pt-BR';
+  const messages = {
+    'pt-BR': {
+      noData: 'Nenhum dado BPMN fornecido.',
+      error: 'Erro ao carregar diagrama: '
+    },
+    'en-US': {
+      noData: 'No BPMN data provided.',
+      error: 'Error loading diagram: '
+    },
+    'es-ES': {
+      noData: 'No se proporcionaron datos BPMN.',
+      error: 'Error al cargar el diagrama: '
+    }
+  };
+  const msg = messages[lang] || messages['en-US'];
   if (!dataParam) {
-      document.body.innerHTML = '<p>No BPMN data provided.</p>';
+      document.body.innerHTML = '<p>' + msg.noData + '</p>';
       return;
     }
     const xml = atob(decodeURIComponent(dataParam));
@@ -25,7 +41,7 @@
   viewer.importXML(xml).then(function(){
     viewer.get('canvas').zoom('fit-viewport');
   }).catch(function(err){
-    document.body.innerHTML = '<pre>Erro ao carregar diagrama: ' + err + '</pre>';
+    document.body.innerHTML = '<pre>' + msg.error + err + '</pre>';
   });
 })();
 </script>

--- a/css/style.css
+++ b/css/style.css
@@ -20,6 +20,9 @@ body {
   color: white;
   padding: 30px;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .content {
@@ -345,3 +348,10 @@ input[type="file"] {
   width: 100%;
   border: none;
 }
+.lang-select {
+  margin-top: 10px;
+  padding: 5px;
+  border-radius: 4px;
+  border: none;
+}
+

--- a/index.html
+++ b/index.html
@@ -10,7 +10,12 @@
     <div class="container">
       <div class="header">
         <h1>🔓 SAP CPI Package Decoder</h1>
-        <p>
+        <select id="langSelect" class="lang-select">
+          <option value="pt-BR">Português</option>
+          <option value="en-US">English</option>
+          <option value="es-ES">Español</option>
+        </select>
+        <p data-i18n="subtitle">
           Decodifique e visualize o conteúdo de pacotes exportados do SAP Cloud
           Integration
         </p>
@@ -18,46 +23,46 @@
 
       <div class="content">
         <div class="info-box">
-          <strong>Como usar:</strong>
+          <strong data-i18n="how_to_use">Como usar:</strong>
           <ol>
             <li>
-              Faça o upload do arquivo <code>.zip</code> exportado do SAP CPI.
+              <span data-i18n="step_upload">Faça o upload do arquivo <code>.zip</code> exportado do SAP CPI.</span>
             </li>
             <li>
-              Os arquivos contidos no pacote serão automaticamente
-              decodificados.
+              <span data-i18n="step_auto">Os arquivos contidos no pacote serão automaticamente
+              decodificados.</span>
             </li>
           </ol>
         </div>
 
         <div class="upload-area" id="uploadArea">
           <div>
-            <h3>📁 Arraste o arquivo .zip aqui ou clique para selecionar</h3>
+            <h3 data-i18n="drag_drop">📁 Arraste o arquivo .zip aqui ou clique para selecionar</h3>
             <button
               class="upload-btn"
               onclick="document.getElementById('fileInput').click()"
             >
-              Selecionar Arquivo ZIP
+              <span data-i18n="select_zip">Selecionar Arquivo ZIP</span>
             </button>
             <input
               type="file"
               id="fileInput"
               accept=".zip"
             />
-            <p style="margin-top: 15px; color: #666">
+            <p style="margin-top: 15px; color: #666" data-i18n="supports_zip">
               Suporta: Pacotes .zip do SAP CPI
             </p>
           </div>
         </div>
 
         <div id="downloadSection" class="result-section" style="display: none; text-align: center;">
-          <button id="downloadBtn" class="download-btn">⬇️ Baixar Recursos Decodificados</button>
+          <button id="downloadBtn" class="download-btn" data-i18n="download_decoded">⬇️ Baixar Recursos Decodificados</button>
         </div>
 
         <div id="results" class="results"></div>
 
         <div class="project-info">
-          <p>
+          <p data-i18n="project_info">
             Este projeto está disponível no
             <a href="https://github.com/lrcherubini/cpi-package-decoder" target="_blank" rel="noopener noreferrer">GitHub</a>.
             Colaborações são bem-vindas!
@@ -70,7 +75,7 @@
     <div id="editorModal" class="modal">
       <div class="modal-content">
         <div class="modal-header">
-          <h3 id="modalTitle">Conteúdo do Arquivo</h3>
+          <h3 id="modalTitle" data-i18n="modal_title">Conteúdo do Arquivo</h3>
           <div class="modal-controls">
             <select id="languageSelect" class="language-select">
               <option value="javascript">JavaScript</option>
@@ -106,6 +111,7 @@
     </div>
 
     <script src="lib/jszip.min.js"></script>
+    <script src="js/i18n.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.44.0/min/vs/loader.min.js"></script>
     <script src="js/globals.js"></script>
     <script src="js/editor.js"></script>

--- a/js/fileLoader.js
+++ b/js/fileLoader.js
@@ -55,7 +55,7 @@ function openResourceInMonaco(resourceId, resourceName, resourceType) {
 
   if (resourceType && resourceType.toUpperCase() === "CONTENTPACKAGE") {
     if (!resourcesCntDecoded) {
-      alert("resources.cnt não encontrado ou não processado.");
+      alert(t("no_resources"));
       return;
     }
     content = resourcesCntDecoded;
@@ -64,7 +64,7 @@ function openResourceInMonaco(resourceId, resourceName, resourceType) {
     const contentFileName = resourceId + "_content";
     content = getFileContent(contentFileName);
     if (!content) {
-      alert("Nenhum conteúdo associado a este recurso.");
+      alert(t("no_content"));
       return;
     }
   }
@@ -86,7 +86,7 @@ function openResourceInMonaco(resourceId, resourceName, resourceType) {
 function openIflowFile(filePath) {
   const content = getFileContent(filePath);
   if (!content) {
-    alert("Arquivo não encontrado: " + filePath);
+    alert(t("file_not_found") + filePath);
     return;
   }
 
@@ -108,7 +108,7 @@ function downloadFileResource(resourceId, resourceName) {
   const contentFileName = resourceId + "_content";
   const content = getFileContent(contentFileName);
   if (!content) {
-    alert("Nenhum conteúdo associado a este recurso.");
+    alert(t("no_content"));
     return;
   }
   const sanitized = (resourceName || resourceId).replace(/[\s/\\?%*:|"<>]/g, "_");
@@ -129,11 +129,11 @@ function processFile(fileName, content) {
   let title = "";
   try {
     if (fileName === "contentmetadata.md") {
-      title = "📋 Metadados do Conteúdo (contentmetadata.md)";
+      title = t("content_metadata_title");
       const decoded = atob(content.trim());
       processedContent = `<div class="code-block">${escapeHtml(decoded)}</div>`;
     } else if (fileName === "resources.cnt") {
-      title = "📦 Recursos do Pacote (resources.cnt)";
+      title = t("package_resources_title");
       const decoded = atob(content.trim());
       const jsonData = JSON.parse(decoded);
       resourcesCntDecoded = JSON.stringify(jsonData, null, 2);
@@ -144,8 +144,8 @@ function processFile(fileName, content) {
       results.appendChild(resultDiv);
     }
   } catch (error) {
-    resultDiv.innerHTML = `<div class="result-title error">❌ Erro ao processar ${fileName}</div>` +
-      `<div class="error">Erro: ${error.message}</div>` +
+    resultDiv.innerHTML = `<div class="result-title error">${t("processing_error_title")}${fileName}</div>` +
+      `<div class="error">${t("error_label")}${error.message}</div>` +
       `<div class="code-block">${escapeHtml(String(content).substring(0, 500))}...</div>`;
     results.appendChild(resultDiv);
   }
@@ -156,7 +156,7 @@ function displayIflowFileList() {
   if (files.length === 0) return;
   const resultDiv = document.createElement("div");
   resultDiv.className = "result-section";
-  let html = '<div class="result-title">📂 Arquivos do IFlow</div>';
+  let html = `<div class="result-title">${t("iflow_files_title")}</div>`;
   html += '<ul class="script-list">';
   files.forEach((fn) => {
     const displayName = fn.split("/").pop();
@@ -166,7 +166,7 @@ function displayIflowFileList() {
             `</li>`;
   });
   html += '</ul>';
-  html += '<p style="margin-top: 15px; color: #666; font-style: italic;">💡 Clique em qualquer arquivo para visualizar seu conteúdo.</p>';
+  html += `<p style="margin-top: 15px; color: #666; font-style: italic;">${t("file_click_hint")}</p>`;
   resultDiv.innerHTML = html;
   results.appendChild(resultDiv);
 }
@@ -174,7 +174,7 @@ function displayIflowFileList() {
 function formatPackageInfo(data) {
   let html = "";
   if (data.resources) {
-    html += "<h5>📋 Recursos encontrados:</h5>";
+    html += `<h5>${t("resources_found")}</h5>`;
     html += '<ul class="script-list">';
     data.resources.forEach((resource) => {
       const urlDataAttr = resource.additionalAttributes.url
@@ -182,11 +182,14 @@ function formatPackageInfo(data) {
         : "";
       html += `<li class="script-item" data-resource-id="${resource.id}" data-resource-type="${resource.resourceType}"${urlDataAttr}>` +
               `<div class="script-name">${resource.displayName || resource.name}</div>` +
-              `<div class="script-type">Tipo: ${resource.resourceType} | Versão: ${resource.semanticVersion || resource.version} | Modificado por: ${resource.modifiedBy}</div>` +
+              `<div class="script-type">${t("resource_details")
+                .replace('{type}', resource.resourceType)
+                .replace('{version}', resource.semanticVersion || resource.version)
+                .replace('{user}', resource.modifiedBy)}</div>` +
               `</li>`;
     });
     html += "</ul>";
-    html += '<p style="margin-top: 15px; color: #666; font-style: italic;">💡 Clique em qualquer recurso para visualizar seu conteúdo no editor. Recursos do tipo URL serão abertos em nova janela</p>';
+    html += `<p style="margin-top: 15px; color: #666; font-style: italic;">${t("resource_click_hint")}</p>`;
   }
   return html;
 }
@@ -199,7 +202,7 @@ function escapeHtml(text) {
 
 function downloadResources() {
   if (!resourcesCntDecoded) {
-    alert("Nenhum recurso processado para download.");
+    alert(t("no_resources_download"));
     return;
   }
 

--- a/js/globals.js
+++ b/js/globals.js
@@ -15,6 +15,7 @@ const downloadBtn = document.getElementById("downloadBtn");
 const bpmnModal = document.getElementById("bpmnModal");
 const bpmnFrame = document.getElementById("bpmnFrame");
 const closeBpmnModal = document.getElementById("closeBpmnModal");
+const langSelect = document.getElementById("langSelect");
 
 let fileContents = {}; // Conteúdo dos arquivos do ZIP principal
 let resourcesCntDecoded = "";

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,0 +1,123 @@
+const translations = {
+  "pt-BR": {
+    title: "SAP CPI Package Decoder",
+    subtitle: "Decodifique e visualize o conteúdo de pacotes exportados do SAP Cloud Integration",
+    how_to_use: "Como usar:",
+    step_upload: "Faça o upload do arquivo <code>.zip</code> exportado do SAP CPI.",
+    step_auto: "Os arquivos contidos no pacote serão automaticamente decodificados.",
+    drag_drop: "📁 Arraste o arquivo .zip aqui ou clique para selecionar",
+    select_zip: "Selecionar Arquivo ZIP",
+    supports_zip: "Suporta: Pacotes .zip do SAP CPI",
+    download_decoded: "⬇️ Baixar Recursos Decodificados",
+    project_info: "Este projeto está disponível no <a href=\"https://github.com/lrcherubini/cpi-package-decoder\" target=\"_blank\" rel=\"noopener noreferrer\">GitHub</a>. Colaborações são bem-vindas!",
+    modal_title: "Conteúdo do Arquivo",
+    format_code: "Formatar código",
+    copy_content: "Copiar conteúdo",
+    view_bpmn: "Visualizar BPMN",
+    fullscreen: "Tela cheia",
+    no_resources: "resources.cnt não encontrado ou não processado.",
+    no_content: "Nenhum conteúdo associado a este recurso.",
+    file_not_found: "Arquivo não encontrado: ",
+    not_bpmn: "Arquivo atual não é um IFLW/BPMN.",
+    no_resources_download: "Nenhum recurso processado para download.",
+    content_metadata_title: "📋 Metadados do Conteúdo (contentmetadata.md)",
+    package_resources_title: "📦 Recursos do Pacote (resources.cnt)",
+    processing_error_title: "❌ Erro ao processar ",
+    error_label: "Erro: ",
+    iflow_files_title: "📂 Arquivos do IFlow",
+    file_click_hint: "💡 Clique em qualquer arquivo para visualizar seu conteúdo.",
+    resources_found: "📋 Recursos encontrados:",
+    resource_details: "Tipo: {type} | Versão: {version} | Modificado por: {user}",
+    resource_click_hint: "💡 Clique em qualquer recurso para visualizar seu conteúdo no editor. Recursos do tipo URL serão abertos em nova janela"
+  },
+  "en-US": {
+    title: "SAP CPI Package Decoder",
+    subtitle: "Decode and view the contents of packages exported from SAP Cloud Integration",
+    how_to_use: "How to use:",
+    step_upload: "Upload the exported <code>.zip</code> file from SAP CPI.",
+    step_auto: "Files inside the package will be automatically decoded.",
+    drag_drop: "📁 Drag the .zip file here or click to select",
+    select_zip: "Select ZIP File",
+    supports_zip: "Supports: SAP CPI package .zip files",
+    download_decoded: "⬇️ Download Decoded Resources",
+    project_info: "This project is available on <a href=\"https://github.com/lrcherubini/cpi-package-decoder\" target=\"_blank\" rel=\"noopener noreferrer\">GitHub</a>. Contributions are welcome!",
+    modal_title: "File Content",
+    format_code: "Format code",
+    copy_content: "Copy content",
+    view_bpmn: "View BPMN",
+    fullscreen: "Fullscreen",
+    no_resources: "resources.cnt not found or not processed.",
+    no_content: "No content associated with this resource.",
+    file_not_found: "File not found: ",
+    not_bpmn: "Current file is not an IFLW/BPMN.",
+    no_resources_download: "No resources processed for download.",
+    content_metadata_title: "📋 Content Metadata (contentmetadata.md)",
+    package_resources_title: "📦 Package Resources (resources.cnt)",
+    processing_error_title: "❌ Error processing ",
+    error_label: "Error: ",
+    iflow_files_title: "📂 IFlow Files",
+    file_click_hint: "💡 Click any file to view its contents.",
+    resources_found: "📋 Resources found:",
+    resource_details: "Type: {type} | Version: {version} | Modified by: {user}",
+    resource_click_hint: "💡 Click any resource to view its content in the editor. URL resources will open in a new window"
+  },
+  "es-ES": {
+    title: "SAP CPI Package Decoder",
+    subtitle: "Decodifica y visualiza el contenido de paquetes exportados de SAP Cloud Integration",
+    how_to_use: "Cómo usar:",
+    step_upload: "Sube el archivo <code>.zip</code> exportado de SAP CPI.",
+    step_auto: "Los archivos del paquete se decodificarán automáticamente.",
+    drag_drop: "📁 Arrastra el archivo .zip aquí o haz clic para seleccionarlo",
+    select_zip: "Seleccionar Archivo ZIP",
+    supports_zip: "Soporta: paquetes .zip de SAP CPI",
+    download_decoded: "⬇️ Descargar Recursos Decodificados",
+    project_info: "Este proyecto está disponible en <a href=\"https://github.com/lrcherubini/cpi-package-decoder\" target=\"_blank\" rel=\"noopener noreferrer\">GitHub</a>. ¡Las contribuciones son bienvenidas!",
+    modal_title: "Contenido del Archivo",
+    format_code: "Formatear código",
+    copy_content: "Copiar contenido",
+    view_bpmn: "Ver BPMN",
+    fullscreen: "Pantalla completa",
+    no_resources: "resources.cnt no encontrado o no procesado.",
+    no_content: "Ningún contenido asociado a este recurso.",
+    file_not_found: "Archivo no encontrado: ",
+    not_bpmn: "El archivo actual no es un IFLW/BPMN.",
+    no_resources_download: "Ningún recurso procesado para descarga.",
+    content_metadata_title: "📋 Metadatos del Contenido (contentmetadata.md)",
+    package_resources_title: "📦 Recursos del Paquete (resources.cnt)",
+    processing_error_title: "❌ Error al procesar ",
+    error_label: "Error: ",
+    iflow_files_title: "📂 Archivos del IFlow",
+    file_click_hint: "💡 Haz clic en cualquier archivo para ver su contenido.",
+    resources_found: "📋 Recursos encontrados:",
+    resource_details: "Tipo: {type} | Versión: {version} | Modificado por: {user}",
+    resource_click_hint: "💡 Haz clic en cualquier recurso para ver su contenido en el editor. Los recursos tipo URL se abrirán en una nueva ventana"
+  }
+};
+
+let currentLang = 'pt-BR';
+
+function t(key) {
+  return translations[currentLang][key] || translations['en-US'][key] || key;
+}
+
+function applyTranslations() {
+  document.documentElement.lang = currentLang;
+  document.querySelectorAll('[data-i18n]').forEach((el) => {
+    const key = el.getAttribute('data-i18n');
+    const text = t(key);
+    el.innerHTML = text;
+  });
+  document.getElementById('formatBtn').title = t('format_code');
+  document.getElementById('copyBtn').title = t('copy_content');
+  document.getElementById('bpmnBtn').title = t('view_bpmn');
+  document.getElementById('fullscreenBtn').title = t('fullscreen');
+}
+
+function setLanguage(lang) {
+  if (translations[lang]) {
+    currentLang = lang;
+    applyTranslations();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', applyTranslations);

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -37,6 +37,10 @@ modal.addEventListener("click", (e) => {
   }
 });
 
+langSelect.addEventListener("change", (e) => {
+  setLanguage(e.target.value);
+});
+
 languageSelect.addEventListener("change", (e) => {
   if (monacoEditor) {
     monaco.editor.setModelLanguage(monacoEditor.getModel(), e.target.value);
@@ -80,13 +84,13 @@ bpmnBtn.addEventListener("click", () => {
   if (!monacoEditor) return;
   const ext = currentFileName.split(".").pop().toLowerCase();
   if (ext !== "iflw" && ext !== "bpmn" && ext !== "xml") {
-    alert("Arquivo atual não é um IFLW/BPMN.");
+    alert(t("not_bpmn"));
     return;
   }
   const xml = monacoEditor.getValue();
   const base64 = btoa(unescape(encodeURIComponent(xml)));
   const encoded = encodeURIComponent(base64);
-  bpmnFrame.src = `bpmn_viewer.html?data=${encoded}`;
+  bpmnFrame.src = `bpmn_viewer.html?data=${encoded}&lang=${currentLang}`;
   bpmnModal.style.display = "block";
   bpmnModal.classList.add("show");
   bpmnModal.querySelector(".modal-content").classList.add("show");


### PR DESCRIPTION
## Summary
- add language selector and i18n system
- translate interface text using js/i18n.js
- pass language to BPMN viewer
- provide README translations in English and Spanish
- minor style tweak for header and language selector

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688ac412f7dc832eb0f2803112039f43