### PR TITLE
Improve file rendering modes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -377,6 +377,62 @@ input[type="file"] {
 .table-view tr:nth-child(even) {
   background: #f8f9fa;
 }
+.metadata-table,
+.resources-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.metadata-table th,
+.metadata-table td,
+.resources-table th,
+.resources-table td {
+  text-align: left;
+  padding: 8px;
+  border-bottom: 1px solid #ddd;
+}
+
+.metadata-table tr:nth-child(even),
+.resources-table tr:nth-child(even) {
+  background-color: #f2f2f2;
+}
+
+.resources-table tr:hover {
+  background-color: #e9e9e9;
+  cursor: pointer;
+}
+
+.selected-row {
+  background-color: #d0d0d0;
+}
+
+.tree-panel {
+  display: flex;
+  gap: 20px;
+}
+
+.tree-panel > div {
+  flex: 1;
+}
+
+.tree-panel ul {
+  list-style-type: none;
+  padding-left: 20px;
+}
+
+.tree-panel li {
+  padding: 4px;
+  cursor: pointer;
+}
+
+.tree-node-icon {
+  margin-right: 5px;
+}
+
+.highlight {
+  background-color: #ffffdd;
+  font-weight: bold;
+}
 .lang-select {
   margin-top: 10px;
   padding: 5px;


### PR DESCRIPTION
## Summary
- expand CSS with table and tree view helpers
- support metadata table rendering for MANIFEST.MF, parameters.prop and .project
- add resources_decoded.json interactive table
- implement dual tree view for `.mmap` mappings

## Testing
- `node -p "require('fs').readFileSync('js/editor.js','utf8');"`

------
https://chatgpt.com/codex/tasks/task_e_688bf4a35710832e872212350a998685