### PR TITLE
Fix initial mmap tree state and improve highlight

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -400,11 +400,12 @@ function buildMmapView(text) {
       li.dataset.path = full;
       if (Object.keys(obj[key]).length) {
         const icon = document.createElement("span");
-        icon.textContent = "►";
+        // Start with nodes expanded
+        icon.textContent = "▼";
         icon.className = "tree-node-icon";
         li.prepend(icon);
         const child = buildTree(obj[key], full);
-        child.style.display = "none";
+        child.style.display = "block";
         li.appendChild(child);
         icon.addEventListener("click", (e) => {
           e.stopPropagation();


### PR DESCRIPTION
## Summary
- expand tree nodes in `.mmap` view by default so related items are visible
- keep existing highlight logic so selecting one side highlights the other

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_688c00e79980832e81a1a95dbad6957c