### PR TITLE
Add view mode toggle and i18n for editor

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -90,21 +90,32 @@ function detectLanguage(fileName) {
 }
 
 function setEditorContent(content, fileName) {
+  // Configurações iniciais do Monaco (permanecem as mesmas)
   const language = detectLanguage(fileName);
   languageSelect.value = language;
   monaco.editor.setModelLanguage(monacoEditor.getModel(), language);
   monacoEditor.setValue(content);
   currentFileName = fileName;
-  isRenderedView = false;
-  
-  document.getElementById("monacoEditor").style.display = "block";
-  renderedView.style.display = "none";
 
   const ext = fileName.split(".").pop().toLowerCase();
-  if (["iflw", "project", "mf", "prop", "propdef", "mmap", "json"].includes(ext)) {
+  const hasRenderedView = ["iflw", "project", "mf", "prop", "propdef", "mmap", "json"].includes(ext);
+
+  if (hasRenderedView) {
+    // **LÓGICA INVERTIDA: RENDERIZADO É O PADRÃO**
+    isRenderedView = true;
     viewSwitchBtn.style.display = "inline-block";
+    viewSwitchBtn.textContent = t('view_code'); // Define o texto para a próxima ação
+
+    showRenderedView(content, currentFileName);
+    renderedView.style.display = "block";
+    document.getElementById("monacoEditor").style.display = "none";
   } else {
+    // Comportamento padrão para arquivos sem visão renderizada
+    isRenderedView = false;
     viewSwitchBtn.style.display = "none";
+    
+    renderedView.style.display = "none";
+    document.getElementById("monacoEditor").style.display = "block";
   }
 }
 
@@ -191,14 +202,19 @@ function prettyPrintXML(xml) {
 
 function toggleViewMode() {
   if (!monacoEditor) return;
+
   if (isRenderedView) {
+    // MUDANDO PARA A VISÃO DE CÓDIGO
     renderedView.style.display = "none";
     document.getElementById("monacoEditor").style.display = "block";
+    viewSwitchBtn.textContent = t('view_rendered'); // Atualiza o texto para a próxima ação
     isRenderedView = false;
   } else {
+    // MUDANDO PARA A VISÃO RENDERIZADA
     showRenderedView(monacoEditor.getValue(), currentFileName);
     renderedView.style.display = "block";
     document.getElementById("monacoEditor").style.display = "none";
+    viewSwitchBtn.textContent = t('view_code'); // Atualiza o texto para a próxima ação
     isRenderedView = true;
   }
 }

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -30,6 +30,8 @@ const translations = {
     resource_details: "Tipo: {type} | Versão: {version} | Modificado por: {user}",
     resource_click_hint: "💡 Clique em qualquer recurso para visualizar seu conteúdo no editor. Recursos do tipo URL serão abertos em nova janela",
     switch_view: "Alternar visualização",
+    view_rendered: "Ver Renderizado", 
+    view_code: "Ver Código",       
     refresh: "Atualizar"
   },
   "en-US": {
@@ -63,6 +65,8 @@ const translations = {
     resource_details: "Type: {type} | Version: {version} | Modified by: {user}",
     resource_click_hint: "💡 Click any resource to view its content in the editor. URL resources will open in a new window",
     switch_view: "Switch View",
+    view_rendered: "View Rendered", 
+    view_code: "View Code",       
     refresh: "Refresh"
   },
   "es-ES": {
@@ -96,6 +100,8 @@ const translations = {
     resource_details: "Tipo: {type} | Versión: {version} | Modificado por: {user}",
     resource_click_hint: "💡 Haz clic en cualquier recurso para ver su contenido en el editor. Los recursos tipo URL se abrirán en una nueva ventana",
     switch_view: "Cambiar vista",
+    view_rendered: "Ver Renderizado", 
+    view_code: "Ver Código",       
     refresh: "Actualizar"
   }
 };


### PR DESCRIPTION
Introduces logic to toggle between code and rendered views in the editor for specific file types. Updates i18n translations to include labels for 'View Rendered' and 'View Code' in supported languages.