### PR TITLE
Fix currentFiles when loading ContentPackage

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1,7 +1,7 @@
 // Editor related functions
 let isRenderedView = false;
 
-function initializeMonacoEditor(content, resourceName) {
+function initializeMonacoEditor(content, resourceName, baseFiles = {}) {
   if (!monacoEditor) {
     monacoEditor = monaco.editor.create(
       document.getElementById("monacoEditor"),
@@ -21,11 +21,11 @@ function initializeMonacoEditor(content, resourceName) {
     );
   }
 
-  loadContentIntoMonaco(content, resourceName);
+  loadContentIntoMonaco(content, resourceName, baseFiles);
 }
 
-function loadContentIntoMonaco(content, resourceName) {
-  currentFiles = {};
+function loadContentIntoMonaco(content, resourceName, baseFiles = {}) {
+  currentFiles = { ...baseFiles };
   fileSelect.style.display = "none";
   fileSelect.innerHTML = "";
 
@@ -45,6 +45,7 @@ function loadContentIntoMonaco(content, resourceName) {
           .file(files[0])
           .async("string")
           .then((scriptContent) => {
+            currentFiles[files[0]] = scriptContent;
             setEditorContent(scriptContent, files[0]);
           });
       } else if (files.length > 1) {
@@ -75,6 +76,7 @@ function loadContentIntoMonaco(content, resourceName) {
       reader.onload = function (e) {
         const textContent = e.target.result;
         setEditorContent(textContent, resourceName);
+        currentFiles[resourceName] = textContent;
       };
       reader.readAsText(new Blob([content]));
     });

--- a/js/fileLoader.js
+++ b/js/fileLoader.js
@@ -76,10 +76,10 @@ function openResourceInMonaco(resourceId, resourceName, resourceType) {
 
   if (!monacoEditor) {
     require(["vs/editor/editor.main"], function () {
-      initializeMonacoEditor(content, fileName);
+      initializeMonacoEditor(content, fileName, fileContents);
     });
   } else {
-    loadContentIntoMonaco(content, fileName);
+    loadContentIntoMonaco(content, fileName, fileContents);
   }
 }
 


### PR DESCRIPTION
## Summary
- preserve existing files when loading single file archives or plain content
- pass extracted zip contents to the editor when opening a ContentPackage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d14292104832eae56f2e006f0918f