### PR TITLE
Fix artifact table click behavior

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -881,8 +881,11 @@ async function buildContentPackageView(packageData, allFilesContent) {
     const artifactsTable = artifactsDiv.querySelector("table");
     if (artifactsTable) {
       enableResourceTableInteraction(artifactsTable, artifacts, (resource) => {
-        console.log("Artefato selecionado:", resource.displayName);
-        alert(`Artefato selecionado: ${resource.displayName}`);
+        openResourceInMonaco(
+          resource.id,
+          resource.displayName || resource.name,
+          resource.resourceType
+        );
       });
       container.appendChild(artifactsTable);
     }


### PR DESCRIPTION
## Summary
- open artifact resources in the editor when clicking rows

## Testing
- `npx -y htmlhint index.html`
- `node --check js/editor.js`

------
https://chatgpt.com/codex/tasks/task_e_688d30cb6cc8832ea41d2e16e775c6cd