### PR TITLE
feat: add package documentation builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
 
         <div id="downloadSection" class="result-section" style="display: none; text-align: center;">
           <button id="downloadBtn" class="download-btn" data-i18n="download_decoded">⬇️ Baixar Recursos Decodificados</button>
+          <button id="docBtn" class="download-btn" data-i18n="build_doc">📘 Build Documentation</button>
           <button id="refreshBtn" class="download-btn" data-i18n="refresh" title="Refresh">🔄</button>
         </div>
 
@@ -112,6 +113,7 @@
     <script src="js/globals.js"></script>
     <script src="js/editor.js"></script>
     <script src="js/fileLoader.js"></script>
+    <script src="js/docBuilder.js"></script>
     <script src="js/uiHandlers.js"></script>
   </body>
 </html>

--- a/js/docBuilder.js
+++ b/js/docBuilder.js
@@ -1,0 +1,53 @@
+function buildDocumentation() {
+  if (!packagesData.length) {
+    alert(t("no_packages_doc"));
+    return;
+  }
+
+  let md = "# SAP CPI Packages Documentation\n\n";
+  packagesData.forEach((pkg, idx) => {
+    const pkgName = pkg.originalZipName || `Package ${idx + 1}`;
+    md += `## ${pkgName}\n\n`;
+
+    const metadataContent = pkg.fileContents["contentmetadata.md"];
+    if (metadataContent) {
+      try {
+        const decoded = atob(metadataContent.trim());
+        md += `### ${t("content_metadata_title")}\n\n`;
+        md += "```\n" + decoded + "\n```\n\n";
+      } catch (e) {
+        console.error("Error decoding content metadata", e);
+      }
+    }
+
+    if (pkg.resourcesCntDecoded) {
+      try {
+        const pkgInfo = JSON.parse(pkg.resourcesCntDecoded);
+        if (pkgInfo.resources && pkgInfo.resources.length > 0) {
+          md += `### ${t("package_resources_title")}\n\n`;
+          md += "| Name | Type | Version | Content Type |\n";
+          md += "|------|------|---------|--------------|\n";
+          pkgInfo.resources.forEach((res) => {
+            const name = res.displayName || res.name || res.id;
+            const type = res.resourceType || "";
+            const version = res.semanticVersion || res.version || "";
+            const ct = res.contentType || "";
+            md += `| ${name} | ${type} | ${version} | ${ct} |\n`;
+          });
+          md += "\n";
+        }
+      } catch (err) {
+        console.error("Error generating documentation for resources", err);
+      }
+    }
+  });
+
+  const blob = new Blob([md], { type: "text/markdown" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = "cpi_package_documentation.md";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(a.href);
+}

--- a/js/globals.js
+++ b/js/globals.js
@@ -12,6 +12,7 @@ const copyBtn = document.getElementById("copyBtn");
 const viewSwitchBtn = document.getElementById("viewSwitchBtn");
 const fullscreenBtn = document.getElementById("fullscreenBtn");
 const downloadBtn = document.getElementById("downloadBtn");
+const docBtn = document.getElementById("docBtn");
 const refreshBtn = document.getElementById("refreshBtn");
 const renderedView = document.getElementById("renderedView");
 const langSelect = document.getElementById("langSelect");

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -9,6 +9,8 @@ const translations = {
     select_zip: "Selecionar Arquivos ZIP",
     supports_zip: "Suporta: Pacotes .zip do SAP CPI",
     download_decoded: "⬇️ Baixar Recursos Decodificados",
+    build_doc: "📘 Gerar Documentação",
+    no_packages_doc: "Nenhum pacote carregado para gerar a documentação.",
     project_info: "Este projeto está disponível no <a href=\"https://github.com/lrcherubini/cpi-package-decoder\" target=\"_blank\" rel=\"noopener noreferrer\">GitHub</a>. Colaborações são bem-vindas!",
     modal_title: "Conteúdo do Arquivo",
     format_code: "Formatar código",
@@ -86,6 +88,8 @@ const translations = {
     select_zip: "Select ZIP Files",
     supports_zip: "Supports: SAP CPI package .zip files",
     download_decoded: "⬇️ Download Decoded Resources",
+    build_doc: "📘 Build Documentation",
+    no_packages_doc: "No packages loaded to generate documentation.",
     project_info: "This project is available on <a href=\"https://github.com/lrcherubini/cpi-package-decoder\" target=\"_blank\" rel=\"noopener noreferrer\">GitHub</a>. Contributions are welcome!",
     modal_title: "File Content",
     format_code: "Format code",
@@ -163,6 +167,8 @@ const translations = {
     select_zip: "Seleccionar Archivos ZIP",
     supports_zip: "Soporta: paquetes .zip de SAP CPI",
     download_decoded: "⬇️ Descargar Recursos Decodificados",
+    build_doc: "📘 Generar Documentación",
+    no_packages_doc: "No hay paquetes cargados para generar la documentación.",
     project_info: "Este proyecto está disponible en <a href=\"https://github.com/lrcherubini/cpi-package-decoder\" target=\"_blank\" rel=\"noopener noreferrer\">GitHub</a>. ¡Las contribuciones son bienvenidas!",
     modal_title: "Contenido del Archivo",
     format_code: "Formatear código",
@@ -250,6 +256,7 @@ function applyTranslations() {
   document.getElementById('viewSwitchBtn').title = t('switch_view');
   document.getElementById('refreshBtn').title = t('refresh');
   document.getElementById('fullscreenBtn').title = t('fullscreen');
+  document.getElementById('docBtn').title = t('build_doc');
   document.getElementById('langSelect').value = currentLang;
 }
 

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -93,6 +93,7 @@ formatBtn.addEventListener("click", () => {
 
 fullscreenBtn.addEventListener("click", toggleFullscreen);
 downloadBtn.addEventListener("click", downloadResources);
+docBtn.addEventListener("click", buildDocumentation);
 
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape" && modal.style.display === "block") {


### PR DESCRIPTION
## Summary
- add button to generate documentation for loaded CPI packages
- support translations for new documentation generator
- export package and resource info into markdown file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d52a0920832e92d5bfa76455b060