### PR TITLE
feat: export documentation as docx

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
     <script src="https://unpkg.com/bpmn-js@17.0.2/dist/bpmn-navigated-viewer.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html-docx-js/0.3.1/html-docx.js"></script>
     <script src="js/i18n.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.44.0/min/vs/loader.min.js"></script>
     <script src="js/globals.js"></script>


### PR DESCRIPTION
## Summary
- generate documentation as Microsoft Word by composing HTML and converting to DOCX
- load html-docx-js in the page to support DOCX export

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a47927dfcc832e8d2706ec66261644